### PR TITLE
lettuce:sepolicy:Compilation Fix

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -5,7 +5,7 @@
 /system/vendor/bin/hw/android\.hardware\.light@2\.0-service\.lettuce      u:object_r:hal_light_default_exec:s0
 
 # Persist
-/dev/block/platform/soc\.0/7824900\.sdhci/by-name/persist                 u:object_r:persist_block_device:s0
+#/dev/block/platform/soc\.0/7824900\.sdhci/by-name/persist                 u:object_r:persist_block_device:s0
 
 # Shell files
 /system/vendor/bin/init\.qcom\.devstart\.sh                               u:object_r:init-qcom-devstart-sh_exec:s0


### PR DESCRIPTION
/root/evo/out/target/product/lettuce/obj/ETC/vendor_file_contexts_intermediates/vendor_file_contexts.tmp: Multiple same specifications for /dev/block/platform/soc\.0/7824900\.sdhci/by-name/persist.
Error: could not load context file from /root/evo/out/target/product/lettuce/obj/ETC/vendor_file_contexts_intermediates/vendor_file_contexts.tmp